### PR TITLE
timers.lua: currentTimer use wrong variable

### DIFF
--- a/src/vscripts/lib/timers.lua
+++ b/src/vscripts/lib/timers.lua
@@ -183,7 +183,7 @@ function Timers:ExecuteTimers(timerList, now)
 	while currentTimer and (now >= currentTimer.endTime) do
 		-- Remove from timers list
 		timerList:Remove(currentTimer)
-		Timers.runningTimer = k
+		Timers.runningTimer = currentTimer
 		Timers.removeSelf = false
 
 		-- Run the callback


### PR DESCRIPTION
the variable "k" is not define,
I read timers version 1.05 by BMD, they use for pairs to define "k", but 1.07 use binary heap and while, so "k" always nil, need use "currentTimer".

If not change, it will throw error when create and remove timer at same frame, with small probability.