### PR TITLE
timers.lua: fix arg1 as string

### DIFF
--- a/src/vscripts/lib/timers.lua
+++ b/src/vscripts/lib/timers.lua
@@ -234,6 +234,9 @@ function Timers:CreateTimer(arg1, arg2, context)
 		timer = {callback = arg1}
 	elseif type(arg1) == "table" then
 		timer = arg1
+	elseif type(arg1) == "string" then
+		timer = arg2
+		timer.name = arg1
 	elseif type(arg1) == "number" then
 		timer = {endTime = arg1, callback = arg2}
 	end
@@ -268,14 +271,17 @@ end
 
 function Timers:RemoveTimer(name)
 	local timerHeap = self.gameTimeHeap
-	if name.useGameTime ~= nil and name.useGameTime == false then
+	local runningTimer = Timers.runningTimer
+	local hasMatch = runningTimer == name or runningTimer.name == name
+
+	if not hasMatch then return end
+
+	if runningTimer.useGameTime ~= nil and runningTimer.useGameTime == false then
 		timerHeap = self.realTimeHeap
 	end
 
-	timerHeap:Remove(name)
-	if Timers.runningTimer == name then
-		Timers.removeSelf = true
-	end
+	timerHeap:Remove(runningTimer)
+	Timers.removeSelf = true
 end
 
 function Timers:InitializeTimers()


### PR DESCRIPTION
makes it possible to use this example. currently it doesn't work
```lua
-- A timer running every second that starts after 2 minutes regardless of pauses
Timers:CreateTimer("uniqueTimerString3", {
    useGameTime = false,
    endTime = 120,
    callback = function()
        print ("Hello. I'm running after 2 minutes and then every second thereafter.")
        return 1
    end
})
```