### PR TITLE
Add sleep function for panorama

### DIFF
--- a/src/panorama/hud.ts
+++ b/src/panorama/hud.ts
@@ -43,3 +43,7 @@ function toArray<T>(obj: Record<number, T>): T[] {
 
     return result;
 }
+
+async function sleep(time: number): Promise<void> {
+    return new Promise<void>((resolve) => $.Schedule(time, resolve));
+}


### PR DESCRIPTION
The sleep functions let's you simplify asynchronous sequences:
```typescript
async function foo() {
    $.Msg("Do something");
    await sleep(3);
    $.Msg("Do something else");
    await sleep(1);
    $.Msg("Do another thing");
    await sleep(0.1);
    $.Msg("Do even more things");
    await sleep(1);
    $.Msg("End with something");
}
```
instead of
```ts
function foo() {
    $.Msg("Do something");
    $.Schedule(3, () => {
        $.Msg("Do something else");
        $.Schedule(1, () => {
            $.Msg("Do another thing");
            $.Schedule(0.1, () => {
                $.Msg("Do even more things");
                $.Schedule(1, () => {
                    $.Msg("End with something");
                });
            });
        });
    });
}
```